### PR TITLE
24H time format on/off setting

### DIFF
--- a/main/src/Screens/Settings/SettingsScreen.cpp
+++ b/main/src/Screens/Settings/SettingsScreen.cpp
@@ -40,7 +40,7 @@ SettingsScreen::SettingsScreen() : settings(*(Settings*) Services.get(Service::S
 	auto startingSettings = settings.get();
 
 	manualTime = new LabelElement(container, "Adjust date/time", [this](){
-		timePickerModal = std::make_unique<TimePickerModal>(this, ts.getTime());
+		timePickerModal = new TimePickerModal(this, ts.getTime());
 	});
 	lv_group_add_obj(inputGroup, *manualTime);
 
@@ -93,6 +93,14 @@ SettingsScreen::SettingsScreen() : settings(*(Settings*) Services.get(Service::S
 	}, startingSettings.screenRotate);
 	lv_group_add_obj(inputGroup, *rotationSwitch);
 
+	timeFormatSwitch = new BoolElement(container, "24-hour format", [this](bool value){
+		auto s = settings.get();
+		s.timeFormat24h = value;
+		settings.set(s);
+		statusBar->set24hFormat(value);
+	}, startingSettings.timeFormat24h);
+	lv_group_add_obj(inputGroup, *timeFormatSwitch);
+
 	saveAndExit = new LabelElement(container, "Save and Exit", [this](){
 		transition([](){ return std::make_unique<MainMenu>(); });
 	});
@@ -110,7 +118,8 @@ void SettingsScreen::loop(){
 			auto eventData = (Input::Data*) evt.data;
 			if(eventData->btn == Input::Alt && eventData->action == Input::Data::Press){
 				if(timePickerModal){
-					timePickerModal.reset();
+					delete timePickerModal;
+					timePickerModal = nullptr;
 				}else{
 					free(evt.data);
 					transition([](){ return std::make_unique<MainMenu>(); });
@@ -132,6 +141,7 @@ void SettingsScreen::onStop(){
 	savedSettings.ledEnable = ledSwitch->getValue();
 	savedSettings.motionDetection = motionSwitch->getValue();
 	savedSettings.screenRotate = rotationSwitch->getValue();
+	savedSettings.timeFormat24h = timeFormatSwitch->getValue();
 	settings.set(savedSettings);
 	settings.store();
 

--- a/main/src/Screens/Settings/SettingsScreen.cpp
+++ b/main/src/Screens/Settings/SettingsScreen.cpp
@@ -39,6 +39,14 @@ SettingsScreen::SettingsScreen() : settings(*(Settings*) Services.get(Service::S
 
 	auto startingSettings = settings.get();
 
+	timeFormatSwitch = new BoolElement(container, "24-hour format", [this](bool value){
+		auto s = settings.get();
+		s.timeFormat24h = value;
+		settings.set(s);
+		statusBar->set24hFormat(value);
+	}, startingSettings.timeFormat24h);
+	lv_group_add_obj(inputGroup, *timeFormatSwitch);
+
 	manualTime = new LabelElement(container, "Adjust date/time", [this](){
 		timePickerModal = new TimePickerModal(this, ts.getTime());
 	});
@@ -92,14 +100,6 @@ SettingsScreen::SettingsScreen() : settings(*(Settings*) Services.get(Service::S
 		settings.set(s);
 	}, startingSettings.screenRotate);
 	lv_group_add_obj(inputGroup, *rotationSwitch);
-
-	timeFormatSwitch = new BoolElement(container, "24-hour format", [this](bool value){
-		auto s = settings.get();
-		s.timeFormat24h = value;
-		settings.set(s);
-		statusBar->set24hFormat(value);
-	}, startingSettings.timeFormat24h);
-	lv_group_add_obj(inputGroup, *timeFormatSwitch);
 
 	saveAndExit = new LabelElement(container, "Save and Exit", [this](){
 		transition([](){ return std::make_unique<MainMenu>(); });

--- a/main/src/Screens/Settings/SettingsScreen.h
+++ b/main/src/Screens/Settings/SettingsScreen.h
@@ -9,6 +9,7 @@
 #include "Services/ChirpSystem.h"
 #include "Devices/IMU.h"
 #include "LV_Interface/LVModal.h"
+#include "TimePickerModal.h"
 
 class BoolElement;
 
@@ -46,8 +47,9 @@ private:
 	LabelElement* saveAndExit;
 	BoolElement* motionSwitch;
 	BoolElement* rotationSwitch;
+	BoolElement* timeFormatSwitch;
 
-	std::unique_ptr<LVModal> timePickerModal;
+	TimePickerModal* timePickerModal = nullptr;
 
 	static constexpr uint8_t TopPadding = 18;
 

--- a/main/src/Screens/Settings/TimePickerModal.h
+++ b/main/src/Screens/Settings/TimePickerModal.h
@@ -20,7 +20,7 @@ private:
 
 	tm time;
 
-	lv_obj_t* hour, * minute, * second, * day, * month, * year;
+	lv_obj_t* hour, * minute, * second, * day, * month, * year, * meridiem;
 	lv_obj_t* timeCont;
 	lv_obj_t* dateCont;
 	LabelElement* saveButton;
@@ -30,6 +30,7 @@ private:
 	LVStyle labelStyle;
 
 	const bool startingInputInversion;
+	const bool timeFormat24h;
 
 	lv_anim_t blinkAnim;
 	static void animFunc(void* var, int32_t val);
@@ -38,6 +39,7 @@ private:
 	static constexpr lv_style_selector_t SelDefault = LV_PART_MAIN | LV_STATE_DEFAULT;
 	static constexpr lv_style_selector_t SelFocus = LV_PART_MAIN | LV_STATE_FOCUSED;
 	static constexpr const char* MonthsNames = "January\nFebruary\nMarch\nApril\nMay\nJune\nJuly\nAugust\nSeptember\nOctober\nNovember\nDecember";
+	static constexpr const char* MeridiemNames = "AM\nPM";
 };
 
 

--- a/main/src/Settings/Settings.h
+++ b/main/src/Settings/Settings.h
@@ -10,6 +10,7 @@ struct SettingsStruct {
 	bool ledEnable = true;
 	bool motionDetection = true;
 	bool screenRotate = false;
+	bool timeFormat24h = true;
 };
 
 class Settings {

--- a/main/src/Theme/devin2.c
+++ b/main/src/Theme/devin2.c
@@ -56,7 +56,16 @@ static LV_ATTRIBUTE_LARGE_CONST const uint8_t glyph_bitmap[] = {
     0x74, 0x62, 0xf0, 0xc5, 0xc0,
 
     /* U+003A ":" */
-    0xf3, 0xc0
+    0xf3, 0xc0,
+
+	/* U+0041 "A" */
+	0x74, 0x63, 0xf8, 0xc6, 0x20,
+
+	/* U+004D "M" */
+	0x8e, 0xeb, 0x58, 0xc6, 0x20,
+
+	/* U+0050 "P" */
+	0xf4, 0x63, 0xe8, 0x42, 0x0,
 };
 
 
@@ -77,7 +86,10 @@ static const lv_font_fmt_txt_glyph_dsc_t glyph_dsc[] = {
     {.bitmap_index = 34, .adv_w = 96, .box_w = 5, .box_h = 7, .ofs_x = 0, .ofs_y = -3},
     {.bitmap_index = 39, .adv_w = 96, .box_w = 5, .box_h = 7, .ofs_x = 0, .ofs_y = -3},
     {.bitmap_index = 44, .adv_w = 96, .box_w = 5, .box_h = 7, .ofs_x = 0, .ofs_y = -3},
-    {.bitmap_index = 49, .adv_w = 64, .box_w = 2, .box_h = 5, .ofs_x = 1, .ofs_y = -3}
+	{.bitmap_index = 49, .adv_w = 64, .box_w = 2, .box_h = 5, .ofs_x = 1, .ofs_y = -3},
+	{.bitmap_index = 51, .adv_w = 96, .box_w = 5, .box_h = 7, .ofs_x = 0, .ofs_y = -3},
+	{.bitmap_index = 56, .adv_w = 96, .box_w = 5, .box_h = 7, .ofs_x = 0, .ofs_y = -3},
+	{.bitmap_index = 61, .adv_w = 96, .box_w = 5, .box_h = 7, .ofs_x = 0, .ofs_y = -3}
 };
 
 /*---------------------
@@ -96,7 +108,19 @@ static const lv_font_fmt_txt_cmap_t cmaps[] =
     {
         .range_start = 48, .range_length = 11, .glyph_id_start = 2,
         .unicode_list = NULL, .glyph_id_ofs_list = NULL, .list_length = 0, .type = LV_FONT_FMT_TXT_CMAP_FORMAT0_TINY
-    }
+    },
+	{
+			.range_start = 65, .range_length = 1, .glyph_id_start = 13,
+			.unicode_list = NULL, .glyph_id_ofs_list = NULL, .list_length = 0, .type = LV_FONT_FMT_TXT_CMAP_FORMAT0_TINY
+	},
+	{
+			.range_start = 77, .range_length = 1, .glyph_id_start = 14,
+			.unicode_list = NULL, .glyph_id_ofs_list = NULL, .list_length = 0, .type = LV_FONT_FMT_TXT_CMAP_FORMAT0_TINY
+	},
+	{
+			.range_start = 80, .range_length = 1, .glyph_id_start = 15,
+			.unicode_list = NULL, .glyph_id_ofs_list = NULL, .list_length = 0, .type = LV_FONT_FMT_TXT_CMAP_FORMAT0_TINY
+	}
 };
 
 
@@ -117,7 +141,7 @@ static lv_font_fmt_txt_dsc_t font_dsc = {
     .cmaps = cmaps,
     .kern_dsc = NULL,
     .kern_scale = 0,
-    .cmap_num = 2,
+    .cmap_num = 5,
     .bpp = 1,
     .kern_classes = 0,
     .bitmap_format = 0,

--- a/main/src/UIElements/ClockLabel.cpp
+++ b/main/src/UIElements/ClockLabel.cpp
@@ -37,10 +37,11 @@ void ClockLabel::updateTime(const tm& time){
 	lastTimeUpdate = millis();
 
 	char clockText[128];
+	const char* ampm = nullptr;
 	if(format24h){
 		snprintf(clockText, sizeof(clockText), "%02d%c%02d", time.tm_hour, time.tm_sec % 2 ? ':' : ' ', time.tm_min);
 	}else{
-		const std::string ampm = time.tm_hour < 12 ? "AM" : "PM";
+		ampm = time.tm_hour < 12 ? "AM" : "PM";
 		int hh = time.tm_hour % 12;
 		if(hh == 0){
 			hh = 12;
@@ -48,7 +49,7 @@ void ClockLabel::updateTime(const tm& time){
 		snprintf(clockText, sizeof(clockText), "%d%c%02d", hh, time.tm_sec % 2 ? ':' : ' ', time.tm_min);
 	}
 
-	updateUI(clockText);
+	updateUI(clockText, ampm);
 	lv_obj_refr_size(*this);
 	lv_obj_invalidate(*this);
 }

--- a/main/src/UIElements/ClockLabel.cpp
+++ b/main/src/UIElements/ClockLabel.cpp
@@ -2,11 +2,14 @@
 #include "Util/Services.h"
 #include "Util/stdafx.h"
 #include "Theme/theme.h"
+#include "Settings/Settings.h"
 
 ClockLabel::ClockLabel(lv_obj_t* parent) : LVObject(parent), ts(*((Time*) Services.get(Service::Time))), queue(2){
 	lv_obj_set_size(obj, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
 
 	Events::listen(Facility::Time, &queue);
+	auto& setts = *(Settings*) Services.get(Service::Settings);
+	set24hFormat(setts.get().timeFormat24h);
 }
 
 ClockLabel::~ClockLabel(){
@@ -34,9 +37,22 @@ void ClockLabel::updateTime(const tm& time){
 	lastTimeUpdate = millis();
 
 	char clockText[128];
-	snprintf(clockText, sizeof(clockText), "%02d%c%02d", time.tm_hour, time.tm_sec % 2 ? ':' : ' ', time.tm_min);
+	if(format24h){
+		snprintf(clockText, sizeof(clockText), "%02d%c%02d", time.tm_hour, time.tm_sec % 2 ? ':' : ' ', time.tm_min);
+	}else{
+		const std::string ampm = time.tm_hour < 12 ? "AM" : "PM";
+		int hh = time.tm_hour % 12;
+		if(hh == 0){
+			hh = 12;
+		}
+		snprintf(clockText, sizeof(clockText), "%d%c%02d", hh, time.tm_sec % 2 ? ':' : ' ', time.tm_min);
+	}
 
 	updateUI(clockText);
 	lv_obj_refr_size(*this);
 	lv_obj_invalidate(*this);
+}
+
+void ClockLabel::set24hFormat(bool format){
+	format24h = format;
 }

--- a/main/src/UIElements/ClockLabel.h
+++ b/main/src/UIElements/ClockLabel.h
@@ -12,6 +12,8 @@ public:
 
 	void loop();
 
+	void set24hFormat(bool format);
+
 protected:
 	void updateTime(const tm& time);
 
@@ -24,6 +26,8 @@ private:
 
 	static constexpr uint32_t TimeUpdateInterval = 200;
 	uint64_t lastTimeUpdate = 0;
+
+	bool format24h = true;
 };
 
 

--- a/main/src/UIElements/ClockLabel.h
+++ b/main/src/UIElements/ClockLabel.h
@@ -20,7 +20,7 @@ protected:
 	Time& ts;
 
 private:
-	virtual void updateUI(const char* clockText) = 0;
+	virtual void updateUI(const char* clockText, const char* ps) = 0;
 
 	EventQueue queue;
 

--- a/main/src/UIElements/ClockLabelBig.cpp
+++ b/main/src/UIElements/ClockLabelBig.cpp
@@ -17,7 +17,7 @@ ClockLabelBig::ClockLabelBig(lv_obj_t* parent) : ClockLabel(parent){
 	updateTime(ts.getTime());
 }
 
-void ClockLabelBig::updateUI(const char* clockText){
+void ClockLabelBig::updateUI(const char* clockText, const char* ps){
 	for(uint8_t i = 0; i < NumIcons; i++){
 		lv_img_set_src(icons[i], getPath(clockText[i]));
 	}

--- a/main/src/UIElements/ClockLabelBig.h
+++ b/main/src/UIElements/ClockLabelBig.h
@@ -8,7 +8,7 @@ public:
 	explicit ClockLabelBig(lv_obj_t* parent);
 	~ClockLabelBig() override = default;
 private:
-	void updateUI(const char* clockText) override;
+	void updateUI(const char* clockText, const char* ps) override;
 
 
 	static constexpr const char* getPath(char c);

--- a/main/src/UIElements/ClockLabelSmall.cpp
+++ b/main/src/UIElements/ClockLabelSmall.cpp
@@ -8,6 +8,11 @@ ClockLabelSmall::ClockLabelSmall(lv_obj_t* parent) : ClockLabel(parent){
 	updateTime(ts.getTime());
 }
 
-void ClockLabelSmall::updateUI(const char* clockText){
-	lv_label_set_text(clock, clockText);
+void ClockLabelSmall::updateUI(const char* clockText, const char* ps){
+	std::string str = clockText;
+	if(ps){
+		str += " ";
+		str += ps;
+	}
+	lv_label_set_text(clock, str.c_str());
 }

--- a/main/src/UIElements/ClockLabelSmall.h
+++ b/main/src/UIElements/ClockLabelSmall.h
@@ -8,7 +8,7 @@ public:
 	explicit ClockLabelSmall(lv_obj_t* parent);
 	~ClockLabelSmall() override = default;
 private:
-	void updateUI(const char* clockText) override;
+	void updateUI(const char* clockText, const char* ps) override;
 	lv_obj_t* clock;
 };
 

--- a/main/src/UIElements/StatusBar.cpp
+++ b/main/src/UIElements/StatusBar.cpp
@@ -109,3 +109,9 @@ void StatusBar::setNotifIcon(){
 		notifPresent = false;
 	}
 }
+
+void StatusBar::set24hFormat(bool format){
+	if(!clock) return;
+
+	clock->set24hFormat(format);
+}

--- a/main/src/UIElements/StatusBar.h
+++ b/main/src/UIElements/StatusBar.h
@@ -18,6 +18,8 @@ public:
 
 	void loop();
 
+	void set24hFormat(bool format);
+
 private:
 	Phone& phone;
 	Battery& battery;


### PR DESCRIPTION
Nazvao sam to u settingsima "24-hour time format" jer sam tak u androidu vidio da se zove setting, ima smisla za amere da je ovo optional stvar.

Po defaultu je na ON, možda to valja promjeniti na OFF.

U manual time pickeru ne mogu napraviti sa lv_spinbox elementom da se AM/PM sati pišu od 1-12, bez leading zerosa. To bi bilo ispravnije po standardu al je jebada s lvglom.