### PR TITLE
Prevent transition from Full to Charging while plugged in

### DIFF
--- a/main/src/Devices/Battery.cpp
+++ b/main/src/Devices/Battery.cpp
@@ -13,7 +13,7 @@ static const char* TAG = "Battery";
 
 Battery::Battery() : Threaded("Battery", 3 * 1024, 5), adc((gpio_num_t) PIN_BATT, 0.05, MIN_READ, MAX_READ, getVoltOffset()),
 					 hysteresis({ 0, 4, 15, 30, 70, 100 }, 3),
-					 chargeHyst(2000, ChargingState::Unplugged), sem(xSemaphoreCreateBinary()), timer(ShortMeasureIntverval, isr, sem){
+					 chargeHyst(500, ChargingState::Unplugged), sem(xSemaphoreCreateBinary()), timer(ShortMeasureIntverval, isr, sem){
 
 	gpio_config_t cfg_gpio = {};
 	cfg_gpio.mode = GPIO_MODE_INPUT;

--- a/main/src/Devices/Battery.cpp
+++ b/main/src/Devices/Battery.cpp
@@ -75,7 +75,12 @@ void Battery::checkCharging(bool fresh){
 	if(!plugin){
 		newState = ChargingState::Unplugged;
 	}else{
-		newState = chrg ? ChargingState::Charging : ChargingState::Full;
+		//Prevent transition from Full to Charging while plugged during current spikes.
+		if(chargeHyst.get() == ChargingState::Full){
+			newState = ChargingState::Full;
+		}else{
+			newState = chrg ? ChargingState::Charging : ChargingState::Full;
+		}
 	}
 
 	if(fresh){


### PR DESCRIPTION
Također sam smanjio hold time histereze jer charge čip (tp4054) ne daje nekakve oscilirajuće vrijednosti na prijelazima.

Ovako je manje laggy kad ukopčaš/iskopčaš punjač, a prijelazi nemaju nikakva titranja (puni/ne puni).